### PR TITLE
Take source IP from HTTP header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# $${\color{red}Deprecated}$$
+MyTutor forked `mod_evasive` to support IPs from a header when Cloudfront WAF did not respond to DOS attacks fast enough (< 5 minutes).
+Modifications were needed to support usage behind a load balancer.
+This is deprecated and no longer necessary for a few reasons:
+* Upon migrating to Cloudflare, Cloudflare's WAF _should_ be sufficient
+* This library is licensed under GPL-2.0, and we don't want to use such a library.
+
 mod_evasive
 ===========
 This version of mod_evasive is managed by ([keklabs/mod_evasive](https://github.com/keklabs/mod_evasive)): keklabs@google.com.

--- a/README.md
+++ b/README.md
@@ -353,6 +353,21 @@ on - when limits exceeded request is logged and processed
 off - when limits exceeded configured HTTPStatus is thrown and request processing is blocked.
 Default off.
 
+#### DOSReportDest
+
+**Context**: server config, virtualhost, directory
+
+If set, JSON reports of every accessing IP together with hit counts are sent
+by UDP to this ip:port.
+
+#### DOSIPFromHeader
+
+**Context**: server config, virtualhost, directory
+
+If set, rather than using the IP address of the connection, take the IP
+address from the named header. This is intended for use behind a load
+balancer.
+
 ## TWEAKING APACHE
 
 The keep-alive settings for your children should be reasonable enough to

--- a/mod_evasive/mod_evasive.c
+++ b/mod_evasive/mod_evasive.c
@@ -280,7 +280,9 @@ static int access_checker(request_rec *r)
 
 					if (cfg->system_command != NULL) {
 						snprintf(filename, sizeof(filename), cfg->system_command, r->useragent_ip);
-						system(filename);
+						if (system(filename)!=0) {
+							ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,"Log command failed: '%s'", filename);
+						}
 					}
 
 				} else {


### PR DESCRIPTION
This is a new feature for operating behind a load balancer.

We take the source IP address from a named HTTP header and use that for rate-limiting. We've been running with this code for a while, it seems to work well. I have also added a debugging feature to optionally transmit real-time alerts of rate limiting via UDP.